### PR TITLE
Updated name of app to RecyclingAssistant

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "WeatherAssistant",
-    "slug": "WeatherAssistant",
+    "name": "RecylingAssistant",
+    "slug": "RecylingAssistant",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "weatherassistant",
+  "name": "recyclingassistant",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "weatherassistant",
+      "name": "recyclingassistant",
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "weatherassistant",
+  "name": "recyclingassistant",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
I want to get another set of eyes on this before I merge it. I changed the name of the app from weather assistant to recycling assistant. 